### PR TITLE
Put callback back in init

### DIFF
--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -64,6 +64,10 @@ function RobinhoodWebApi(opts, callback) {
     _setHeaders();
     _login(function(){
       _isInit = true;
+
+      if (callback) {
+        callback.call();
+      }
     });
   }
 


### PR DESCRIPTION
- Put the callback into init `_login` call because without it
  we dont know when we are logged in
- Added a check to see if `callback` was passed in before trying
  to call it

aurbano/robinhood-node#8