### PR TITLE
stop_price field added to _place_order() for #27

### DIFF
--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -155,6 +155,7 @@ function RobinhoodWebApi(opts, callback) {
           account: _private.account,
           instrument: options.instrument.url,
           price: options.bid_price,
+          stop_price: options.stop_price,
           quantity: options.quantity,
           side: options.transaction,
           symbol: options.instrument.symbol.toUpperCase(),


### PR DESCRIPTION
Fixes #27, enables use of stop* orders.

Tested and confirmed via app UI by creation of stop loss order.