### PR TITLE
Accept multiple symbols for quote data

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Values can be:
 * Jason Truluck ([@jasontruluck](https://github.com/jasontruluck))
 * Justin Keller ([@nodesocket](https://github.com/nodesocket))
 * Chris Busse ([@busse](https://github.com/busse))
+* Jon Callahan ([@jondcallahan](https://github.com/jondcallahan))
 
 ------------------
 This framework is still in a very alpha version and will likely change, so production usage is completely discouraged.

--- a/examples/get_quote.js
+++ b/examples/get_quote.js
@@ -1,5 +1,7 @@
 var Robinhood = require('../src/robinhood');
 
+// The quote_data() method can take a string or an array of symbols,
+// and is case insensitive. ex: 'GOOG' or ['goog', 'AAPL', 'spy']
 Robinhood(null).quote_data('GOOG', function(error, response, body) {
     if (error) {
         console.error(error);

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -119,6 +119,7 @@ function RobinhoodWebApi(opts, callback) {
   };
 
   api.quote_data = function(symbol, callback){
+    Array.isArray(symbol) ? symbol = symbol.join(',') : null
     return _request.get({
         uri: _endpoints.quotes,
         qs: { 'symbols': symbol.toUpperCase() }

--- a/test/robinhood.js
+++ b/test/robinhood.js
@@ -8,15 +8,28 @@ var should = require('should');
 var Robinhood = require('../src/robinhood');
 
 describe('Robinhood API', function() {
-    it('Should get GOOG quote', function(done) {
-        Robinhood(null).quote_data('GOOG', function(err, response, body) {
-            if(err) {
-                done(err);
-                return;
-            }
-
+    it('Should accept an array of ticker symbols', (done) => {
+        Robinhood(null).quote_data(['GOOG', 'AAPL', 'FB'], (err, response, body) => {
+            should.not.exist(err);
+            body.results.should.be.an.instanceOf(Array).and.have.lengthOf(3);
             console.log(body);
             done();
         });
+    });
+    it('Should accept a single ticker symbol', (done) => {
+      Robinhood(null).quote_data('GOOG', (err, response, body) => {
+        should.not.exist(err);
+        body.results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
+        console.log(body);
+        done();
+      })
+    });
+    it('Should be case insensitive', (done) => {
+      Robinhood(null).quote_data(['AaPl', 'goog', 'FB'], (err, response, body) => {
+        should.not.exist(err);
+        body.results.should.be.an.instanceOf(Array).and.have.lengthOf(3);
+        console.log(body);
+        done();
+      });
     });
 });


### PR DESCRIPTION
This PR adds the ability to pass an array of symbols to the `quote_data()` method. It does a quick check to see if the argument is an array and joins them if so, otherwise the argument falls through to the request.
