### PR TITLE
Added a method `url` to retrive paginated data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
     * [`sp500_down(callback)`](#sp500-downcallback)
     * [`splits(instrument, callback)`](#splitsinstrument-callback)
     * [`historicals(symbol, intv, span, callback)`](#historicalssymbol-intv-span-callback)
-    * [`url(url, callback)`](#url-url-callback)
+    * [`url(url, callback)`](#urlurl-callback)
 * [Contributors](#contributors)
 
 <!-- toc stop -->

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
     * [`sp500_down(callback)`](#sp500-downcallback)
     * [`splits(instrument, callback)`](#splitsinstrument-callback)
     * [`historicals(symbol, intv, span, callback)`](#historicalssymbol-intv-span-callback)
+    * [`url(url, callback)`](#url-url-callback)
 * [Contributors](#contributors)
 
 <!-- toc stop -->
@@ -608,6 +609,16 @@ var Robinhood = require('robinhood')(credentials, function(){
     })
 })
 ```
+
+### `url(url, callback)`
+
+`url` is used to get continued or paginated data from the API. Queries with long results return a reference to the next sete. Example -
+
+```
+next: 'https://api.robinhood.com/orders/?cursor=cD0yMD82LTA0LTAzKzkwJVNCNTclM0ExNC45MzYyKDYlMkIwoCUzqtAW' }
+```
+
+The url returned can be passed to the `url` method to continue getting the next set of results.
 
 # Contributors
 

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -277,6 +277,12 @@ function RobinhoodWebApi(opts, callback) {
         uri: _apiUrl + [_endpoints.quotes + 'historicals/','/?interval='+intv+'&span='+span].join(symbol)
       }, callback);
   };
+  
+  api.url = function (url,callback){
+    return _request.get({
+      uri:url
+    },callback);
+  };
 
   _init(_options);
 


### PR DESCRIPTION
Added a method `url` to retrive paginated data sets. Intended to be used as -

```
Robinhood.url('https://api.robinhood.com/orders/?cursor=cD0yM...DE2w',function(err,response,body){
    if(err){
        console.error(err);
    }else{
        console.log("Continued result set...");
        console.log(body);
    }
});
```

It may also be used for -

```
Robinhood.url('https://api.robinhood.com/user/basic_info/',function(err,response,body){
    if(err){
        console.error(err);
    }else{
        console.log("User Basic Info");
        console.log(body);
    }
});
```