### PR TITLE
Adding nonzero positions call

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
     * [`user(callback)`](#usercallback)
     * [`dividends(callback)`](#dividendscallback)
     * [`orders(callback)`](#orderscallback)
+    * [`positions(callback)`](#positionscallback)
+    * [`nonzero_positions(callback)`](#nonzero-positions-callback)
     * [`place_buy_order(options, callback)`](#place-buy-orderoptions-callback)
       * [`trigger`](#trigger)
       * [`time`](#time)
@@ -279,6 +281,39 @@ var Robinhood = require('robinhood')(credentials, function(){
     })
 });
 ```
+
+### `positions(callback)`
+
+Get the user's position information.
+```typescript
+var Robinhood = require('robinhood')(credentials, function(){
+    Robinhood.positions(function(err, response, body){
+        if (err){
+            console.erro(err);
+        }else{
+            console.log("positions");
+            console.log(body);
+        }
+    });
+});
+```
+
+### `nonzero_positions(callback)`
+
+Get the user's nonzero position information only.
+```typescript
+var Robinhood = require('robinhood')(credentials, function(){
+    Robinhood.nonzero_positions(function(err, response, body){
+        if (err){
+            console.erro(err);
+        }else{
+            console.log("positions");
+            console.log(body);
+        }
+    });
+});
+```
+
 ### `place_buy_order(options, callback)`
 
 Place a buy order on a specified stock.

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -227,6 +227,13 @@ function RobinhoodWebApi(opts, callback) {
     }, callback);
   };
 
+  api.nonzero_positions = function(callback){
+    return _request.get({
+      uri: _endpoints.positions,
+      qs: {nonzero: true}
+    }, callback);
+  };
+
   api.news = function(symbol, callback){
     return _request.get({
       uri: _apiUrl + [_endpoints.news,'/'].join(symbol)

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -229,7 +229,7 @@ function RobinhoodWebApi(opts, callback) {
 
   api.nonzero_positions = function(callback){
     return _request.get({
-      uri: _endpoints.positions,
+      uri: _apiUrl + _endpoints.positions,
       qs: {nonzero: true}
     }, callback);
   };

--- a/test/robinhood.js
+++ b/test/robinhood.js
@@ -74,3 +74,14 @@ test('Should not get positions without login', function(t) {
         t.true(body.detail);
     });
 });
+
+test('Should not get nonzero positions without credentials', function(t){
+    Robinhood(null).nonzero_positions(function(err,response,body) {
+        if(err) {
+            done(err);
+            return;
+        }
+
+        t.true(body.detail);
+    })
+})

--- a/test/robinhood.js
+++ b/test/robinhood.js
@@ -83,5 +83,5 @@ test('Should not get nonzero positions without credentials', function(t){
         }
 
         t.true(body.detail);
-    })
-})
+    });
+});


### PR DESCRIPTION
Adding nonzero_positions call to the API.

This call returns all nonzero positions currently held by the authenticated user and can be useful for looking at current portfolios.