### PR TITLE
supporting direct token authentication and retrieval of active auth_t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
   * [Installation](#installation)
   * [Usage](#usage)
   * [API](#api)
-    * [`investment_profile(callback)`](#investment-profilecallback)
+    * [`auth_token()`](#auth_token)
+    * [`investment_profile(callback)`](#investment_profilecallback)
     * [`instruments(symbol, callback)`](#instrumentssymbol-callback)
     * [`quote_data(stock, callback) // Not authenticated`](#quote-datastock-callback-not-authenticated)
     * [`accounts(callback)`](#accountscallback)
@@ -56,6 +57,9 @@ $ npm install robinhood --save
 
 ## Usage
 
+To authenticate, you can either use your username and password to the Robinhood app or a previously authenticated Robinhood api token:
+
+### Username & Password
 ```js
 //The username and password you use to sign into the robinhood app.
 
@@ -63,7 +67,18 @@ var credentials = {
     username: '',
     password: ''
 };
+```
 
+### Robinhood API Auth Token
+```js
+//A previously authenticated Robinhood API auth token
+
+var credentials = {
+    token: ''
+};
+```
+
+```js
 var Robinhood = require('robinhood')(credentials, function(){
 
     //Robinhood is connected and you may begin sending commands to the api.
@@ -82,6 +97,17 @@ var Robinhood = require('robinhood')(credentials, function(){
 ## API
 
 Before using these methods, make sure you have initialized Robinhood using the snippet above.
+
+### `auth_token()`
+Get the current authenticated Robinhood api authentication token
+
+```typescript
+var credentials = require("../credentials.js")();
+var Robinhood = require('robinhood')(credentials, function(){
+    console.log(Robinhood.auth_token());
+        //      <authenticated alphanumeric token>
+}
+```
 
 ### `investment_profile(callback)`
 Get the current user's investment profile.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinhood",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Comprehensive NodeJS API wrapper for the Robinhood API",
   "main": "src/robinhood.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "nyc": "^10.0.0"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "promise": "^7.1.1",
     "request": "^2.79.0",
     "should": "^11.1.1"


### PR DESCRIPTION
…oken via the api

Alejandro, I am an active user of your RH api wrapper.  It has been a pleasure working with this tool so far.  I am starting to take some of my development to the next level and would like to have a way to authenticate directly to RH using their token so I can have multiple accounts on my server sharing this resource without having to store their usernames and passwords.  

This pull request does two main things:

1. Allows for consumers of your wrapper to use a Robinhood api auth token directly with the library as an alternative authorization method in addition to username & password.

2. Includes a 'getter' for retrieving the currently authenticated auth_token from the wrapper's api so the consumer can store it for future authentication (via item #1 above).

I humbly present this merge request for your consideration.

Thanks,
Matt Herron (@swimclan)