### PR TITLE
Updated request headers to use latest iOS/app version user agent and …

### DIFF
--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -76,9 +76,9 @@ function RobinhoodWebApi(opts, callback) {
         'Accept-Encoding': 'gzip, deflate',
         'Accept-Language': 'en;q=1, fr;q=0.9, de;q=0.8, ja;q=0.7, nl;q=0.6, it;q=0.5',
         'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
-        'X-Robinhood-API-Version': '1.0.0',
         'Connection': 'keep-alive',
-        'User-Agent': 'Robinhood/823 (iPhone; iOS 7.1.2; Scale/2.00)'
+        'X-Robinhood-API-Version': '1.152.0',
+        'User-Agent': 'Robinhood/5.32.0 (com.robinhood.release.Robinhood; build:3814; iOS 10.3.3)'
     };
     _setHeaders();
     if (!_private.auth_token) {


### PR DESCRIPTION
…latest RH api release

@aurbano I observed the request header being sent by the current version of the iOS app and have updated the header fields accordingly in this PR.  I tested most of the endpoints that either require authentication or can be called anonymously with positive results.  I am hoping this reduces the 'unfilled' order counts I am occasionally getting when executing orders through the wrapper.

Thanks for your consideration,
Matt (@swimclan)