### PR TITLE
Added method to expire token and logout of robinhood

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
   * [Usage](#usage)
   * [API](#api)
     * [`auth_token()`](#auth_token)
+    * [`expire_token(callback)`](#expire_token)
     * [`investment_profile(callback)`](#investment_profilecallback)
     * [`instruments(symbol, callback)`](#instrumentssymbol-callback)
     * [`quote_data(stock, callback) // Not authenticated`](#quote-datastock-callback-not-authenticated)
@@ -108,6 +109,25 @@ var Robinhood = require('robinhood')(credentials, function(){
     console.log(Robinhood.auth_token());
         //      <authenticated alphanumeric token>
 }
+```
+
+### `expire_token()`
+Expire the current authenticated Robinhood api token (logout). 
+
+> **NOTE:** After expiring a token you will need to reinstantiate the package with username & password in order to get a new token!
+
+```typescript
+var credentials = require("../credentials.js")();
+var Robinhood = require('robinhood')(credentials, function(){
+    Robinhood.expire_token(function(err, response, body){
+        if(err){
+            console.error(err);
+        }else{
+            console.log("Successfully logged out of Robinhood and expired token.");
+            // NOTE: body is undefined on the callback
+        }
+    })
+});
 ```
 
 ### `investment_profile(callback)`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinhood",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Comprehensive NodeJS API wrapper for the Robinhood API",
   "main": "src/robinhood.js",
   "scripts": {

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -22,6 +22,7 @@ function RobinhoodWebApi(opts, callback) {
       // Private API Endpoints
       _endpoints = {
         login:  'api-token-auth/',
+        logout: 'api-token-logout/',
         investment_profile: 'user/investment_profile/',
         accounts: 'accounts/',
         ach_iav_auth: 'ach/iav/auth/',
@@ -158,6 +159,14 @@ function RobinhoodWebApi(opts, callback) {
    * +--------------------------------+ */
   api.auth_token = function() {
     return _private.auth_token;
+  };
+
+  // Invoke robinhood logout.  Note: User will need to reintantiate
+  // this package to get a new token!
+  api.expire_token = function(callback) {
+    return _request.post({
+      uri: _apiUrl + _endpoints.logout
+    }, callback);
   };
 
   api.investment_profile = function(callback){


### PR DESCRIPTION
Alejandro-

Thought this would be a useful method for maintaining secure connections to Robinhood.  By allowing consumers to expire the current token they secure their RH accounts and prevent any potential abuse / unwanted token distribution.

Thanks for your consideration.

Matt