### PR TITLE
Augmented orders method to accept instrument and date limiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
     * [`accounts(callback)`](#accountscallback)
     * [`user(callback)`](#usercallback)
     * [`dividends(callback)`](#dividendscallback)
-    * [`orders(callback)`](#orderscallback)
+    * [`orders(options, callback)`](#ordersoptions-callback)
     * [`positions(callback)`](#positionscallback)
     * [`nonzero_positions(callback)`](#nonzero_positionscallback)
     * [`place_buy_order(options, callback)`](#place-buy-orderoptions-callback)
@@ -313,12 +313,21 @@ var Robinhood = require('robinhood')(credentials, function(){
 ```
 
 
-### `orders(callback)`
+### `orders(options, callback)`
 
-Get the user's orders information.
+Get the user's orders information.  Send options hash (optional) to limit to specific instrument and/or earliest date of orders.
+
+```typescript
+// optional options hash.  If no hash is sent, all orders will be returned.
+let options = {
+    updated_at: '2017-08-25',
+    instrument: 'https://api.robinhood.com/instruments/df6c09dc-bb4f-4495-8c59-f13e6eb3641f/'
+}
+```
+
 ```typescript
 var Robinhood = require('robinhood')(credentials, function(){
-    Robinhood.orders(function(err, response, body){
+    Robinhood.orders(options, function(err, response, body){
         if(err){
             console.error(err);
         }else{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinhood",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Comprehensive NodeJS API wrapper for the Robinhood API",
   "main": "src/robinhood.js",
   "scripts": {
@@ -32,6 +32,7 @@
     "lodash": "^4.17.4",
     "promise": "^7.1.1",
     "request": "^2.79.0",
-    "should": "^11.1.1"
+    "should": "^11.1.1",
+    "query-string": "^4.3.2"
   }
 }

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -2,6 +2,7 @@
  * Robinhood API NodeJS Wrapper
  * @author Alejandro U. Alvarez
  * @license AGPLv3 - See LICENSE file for more details
+ * @version 1.1.1
  */
 
 'use strict';
@@ -10,6 +11,7 @@
 var request = require('request');
 var Promise = require('promise');
 var _ = require('lodash');
+var queryString = require('query-string');
 
 function RobinhoodWebApi(opts, callback) {
 
@@ -215,9 +217,19 @@ function RobinhoodWebApi(opts, callback) {
     }, callback);
   };
 
-  api.orders = function(callback){
+  api.orders = function(){
+    var options = {}, callback = new Function(), args = _.values(arguments);
+    args.forEach(function(arg) {
+      if (typeof arg === 'function') callback = arg;
+      if (typeof arg === 'object') options = arg;     // Keep in mind, instrument option must be the full instrument url!
+    });
+    var hasOptions = _.keys(options).length > 0;
+    if (hasOptions) {
+      options['updated_at[gte]'] = options.updated_at;
+      _.unset(options, 'updated_at');
+    }
     return _request.get({
-      uri: _apiUrl + _endpoints.orders
+      uri: _apiUrl + _endpoints.orders + (hasOptions ? '?' + queryString.stringify(options) : '')
     }, callback);
   };
 


### PR DESCRIPTION
@aurbano Implemented additional functionality in the orders api method.  Now consumers can send an optional 'options' hash to the orders method to limit returned orders data to specific instrument and/or limit to orders placed on or after a specified date.

This is not a breaking change and allows existing consumers to continue sending just a callback to expect an exhaustive, paginated collection of all their orders.