### PR TITLE
Added defensive code in set_account for when user isnt approved yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinhood",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Comprehensive NodeJS API wrapper for the Robinhood API",
   "main": "src/robinhood.js",
   "scripts": {

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -2,7 +2,7 @@
  * Robinhood API NodeJS Wrapper
  * @author Alejandro U. Alvarez
  * @license AGPLv3 - See LICENSE file for more details
- * @version 1.1.1
+ * @version 1.1.2
  */
 
 'use strict';
@@ -143,8 +143,8 @@ function RobinhoodWebApi(opts, callback) {
         if (err) {
           reject(err);
         }
-
-        if (body.results) {
+        // Being defensive when user credentials are valid but RH has not approved an account yet
+        if (body.results && body.results instanceof Array && body.results.length > 0) {
           _private.account = body.results[0].url;
         }
         resolve();


### PR DESCRIPTION
Defending against js exceptions when no account is returned from RH (ie when signed up but not yet approved)