### PR TITLE
Fix for orders() method

### DIFF
--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -225,7 +225,7 @@ function RobinhoodWebApi(opts, callback) {
       if (typeof arg === 'object') options = arg;     // Keep in mind, instrument option must be the full instrument url!
     });
 
-    var hasId = typeof id !== "undefined";
+    var hasId = typeof id !== "undefined" && id !== null;
     var hasOptions = _.keys(options).length > 0;
 
     if(hasId && hasOptions){ // remove ambiguitiy from choosing both an id and options


### PR DESCRIPTION
Fix for orders() method: hasId became null in some cases and method failed.

Easy to reproduce if run this statement:
Robinhood.orders({ updated_at: '2018-01-23' }, function(err, resp, body) { ... }