### PR TITLE
feature: add popularity api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
     * [`url(url, callback)`](#urlurl-callback)
     * [`news(symbol, callback)`](#newssymbol-callback)
     * [`tag(tag, callback)`](#tagtag-callback)
+    * [`popularity(symbol, callback)`](#popularitysymbol-callback)
 * [Contributors](#contributors)
 
 <!-- toc stop -->
@@ -839,6 +840,28 @@ Response sample:
 }
 ```
 
+### `popularity(symbol, callback)`
+
+Get the popularity for a specified stock.
+
+
+```typescript
+var credentials = require("../credentials.js")();
+var Robinhood = require('robinhood')(credentials, function() {
+    Robinhood.popularity('GOOG', function(error, response, body) {
+        if (error) {
+            console.error(error);
+        } else {
+            console.log(body);
+            // {
+            //    instrument: 'https://api.robinhood.com/instruments/943c5009-a0bb-4665-8cf4-a95dab5874e4/',
+            //    num_open_positions: 16319
+            // }
+        }
+    });
+});
+```
+
 ### news(symbol, callback)
 
 Return news about a symbol.
@@ -859,6 +882,7 @@ Alejandro U. Alvarez ([@aurbano](https://github.com/aurbano))
 * Chris Busse ([@busse](https://github.com/busse))
 * Jason Truluck ([@jasontruluck](https://github.com/jasontruluck))
 * Matthew Herron ([@swimclan](https://github.com/swimclan))
+* Chris Dituri ([@cdituri](https://github.com/cdituri))
 
 ------------------
 

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -223,6 +223,21 @@ function RobinhoodWebApi(opts, callback) {
       }, callback);
   };
 
+  api.popularity = function(symbol, callback){
+    return api.quote_data(symbol, function (error, response, body) {
+        if (error) {
+            return callback(error, response, body);
+        }
+
+        // ex. https://api.robinhood.com/instruments/edf89445-db53-4f97-9de9-a599a293c63f/
+        var symbol_uuid = body.results[0].instrument.split('/')[4];
+
+        return _request.get({
+            uri: _apiUrl + _endpoints.instruments + symbol_uuid + '/popularity/',
+        }, callback);
+    });
+  };
+
   api.quote_data = function(symbol, callback){
     symbol = Array.isArray(symbol) ? symbol = symbol.join(',') : symbol;
     return _request.get({


### PR DESCRIPTION
Adds a method to retrieve the popularity of a symbol.

**Note**: this method dispatches two requests. The first is to the quotes endpoint to determine the uuid of the target symbol; the second is to the popularity api endpoint itself, which consumes the uuid of the target symbol.

Example usage:
```
const Robinhood = require('./src/robinhood')(credentials, () => {
    Robinhood.popularity('GOOG', (err, response, body) => {
        console.log(body);
    });
});
```

returns the following:
```
{
   instrument: 'https://api.robinhood.com/instruments/943c5009-a0bb-4665-8cf4-a95dab5874e4/'',
   num_open_positions: 16319
}
```