### PR TITLE
make login and logout use Robinhood's OAuth2 endpoints

### DIFF
--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -136,7 +136,7 @@ function RobinhoodWebApi(opts, callback) {
         throw (err);
       }
 
-      if (!body.token) {
+      if (!body.access_token) {
           throw new Error(
               "token not found " + JSON.stringify(httpResponse)
           )

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -70,6 +70,7 @@ function RobinhoodWebApi(opts, callback) {
       password : null,
       headers : null,
       auth_token : null,
+      refresh_token: null
     },
     api = {};
 

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -23,8 +23,8 @@ function RobinhoodWebApi(opts, callback) {
   var _options = opts || {},
       // Private API Endpoints
       _endpoints = {
-        login:  'api-token-auth/',
-        logout: 'api-token-logout/',
+        login:  'oauth2/token/',
+        logout: 'oauth2/revoke_token/',
         investment_profile: 'user/investment_profile/',
         accounts: 'accounts/',
         ach_iav_auth: 'ach/iav/auth/',
@@ -60,6 +60,7 @@ function RobinhoodWebApi(opts, callback) {
         news: 'midlands/news/',
         tag: 'midlands/tags/tag/'
     },
+    _clientId = 'c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS',
     _isInit = false,
     _request = request.defaults(),
     _private = {
@@ -69,7 +70,6 @@ function RobinhoodWebApi(opts, callback) {
       password : null,
       headers : null,
       auth_token : null,
-      mfa_code : null
     },
     api = {};
 
@@ -120,44 +120,39 @@ function RobinhoodWebApi(opts, callback) {
   }
 
   function _login(callback){
-    var form = {
-          password: _private.password,
-          username: _private.username
-      };
-
-    if (_private.mfa_code) {
-      form.mfa_code = _private.mfa_code
-    }
 
     _request.post({
       uri: _apiUrl + _endpoints.login,
-      form: form
+      form: {
+        grant_type: "password",
+        scope: "internal",
+        client_id: _clientId,
+        // expires_in: 86400,
+        password: _private.password,
+        username: _private.username
+      }
     }, function(err, httpResponse, body) {
       if(err) {
         throw (err);
       }
 
-      if (body.mfa_required && body.mfa_required === true) {
-        callback(body);
+      if (!body.token) {
+          throw new Error(
+              "token not found " + JSON.stringify(httpResponse)
+          )
       }
-      else {
-          if (!body.token) {
-              throw new Error(
-                  "token not found " + JSON.stringify(httpResponse)
-              )
-          }
-          _private.auth_token = body.token;
-          _build_auth_header(_private.auth_token);
+      _private.auth_token = body.access_token;
+      _private.refresh_token = body.refresh_token;
+      _build_auth_header(_private.auth_token);
 
-          _setHeaders();
+      _setHeaders();
 
-          // Set account
-          _set_account().then(function() {
-              callback.call();
-          }).catch(function(err) {
-              throw (err);
-          })
-      }
+      // Set account
+      _set_account().then(function() {
+          callback.call();
+      }).catch(function(err) {
+          throw (err);
+      })
     });
   }
 
@@ -177,19 +172,12 @@ function RobinhoodWebApi(opts, callback) {
   }
 
   function _build_auth_header(token) {
-    _private.headers.Authorization = 'Token ' + token;
+    _private.headers.Authorization = 'Bearer ' + token;
   }
 
   /* +--------------------------------+ *
    * |      Define API methods        | *
    * +--------------------------------+ */
-
-  // Sets the mfa_code variable and initiates the login process again
-  api.set_mfa_code = function(mfa_code, callback) {
-    _private.mfa_code = mfa_code;
-
-    _login(callback);
-  };
 
   api.auth_token = function() {
     return _private.auth_token;
@@ -199,7 +187,11 @@ function RobinhoodWebApi(opts, callback) {
   // this package to get a new token!
   api.expire_token = function(callback) {
     return _request.post({
-      uri: _apiUrl + _endpoints.logout
+      uri: _apiUrl + _endpoints.logout,
+      form: {
+        client_id: _clientId,
+        token: _private.refresh_token
+      }
     }, callback);
   };
 


### PR DESCRIPTION
It seems Robinhood may have stopped supporting these endpoints: `/api-token-auth` and `/api-token-logout`.  I as well as others noticed a 404 response when authenticating starting yesterday. 

This PR implements login and logout according to the OAuth2 spec that is being used by the official Robinhood web app.

Unsure of whether the `mfa_code` part of the code is still desired.

Opened a related issue here:
https://github.com/aurbano/robinhood-node/issues/77