### PR TITLE
bugfix: update fundamentals call

### DIFF
--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -205,8 +205,7 @@ function RobinhoodWebApi(opts, callback) {
 
   api.fundamentals = function(ticker, callback){
     return _request.get({
-        uri: _apiUrl + _endpoints.fundamentals,
-        qs: { 'symbols': ticker }
+		uri: _apiUrl + [_endpoints.fundamentals,'/'].join(String(ticker).toUpperCase()),
       }, callback);
   };
 
@@ -257,7 +256,7 @@ function RobinhoodWebApi(opts, callback) {
       uri: _apiUrl + _endpoints.dividends
     }, callback);
   };
-  
+
   api.earnings = function(options, callback){
     return _request.get({
       uri: _apiUrl + _endpoints.earnings +
@@ -360,7 +359,7 @@ function RobinhoodWebApi(opts, callback) {
       uri: _apiUrl + [_endpoints.news,'/'].join(symbol)
     }, callback);
   };
-  
+
   api.tag = function(tag, callback){
     return _request.get({
       uri: _apiUrl + _endpoints.tag + tag

--- a/test/robinhood.js
+++ b/test/robinhood.js
@@ -20,6 +20,18 @@ test('Should get ' + TEST_SYMBOL + ' quote', function(t) {
     });
 });
 
+test('Should get ' + TEST_SYMBOL + ' fundamentals', function(t) {
+    Robinhood(null).fundamentals(TEST_SYMBOL, function(err, response, body) {
+        if(err) {
+            done(err);
+            return;
+        }
+
+        // TODO make this test better
+        t.is(Object.keys(body).length, 21);
+    });
+});
+
 test('Should get markets', function(t) {
     Robinhood(null).markets(function(err, response, body) {
         if(err) {


### PR DESCRIPTION
The fundamentals endpoint is used thusly:
```sh
curl https://api.robinhood.com/fundamentals/OGEN/
```
The current code runs:
```sh
curl https://api.robinhood.com/fundamentals/?symbol=OGEN
```
Which fails.

This PR updates the API to use the correct endpoint.