### PR TITLE
Adding Options Orders History

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ FYI [Robinhood's Terms and Conditions](https://brokerage-static.s3.amazonaws.com
     * [`tag(tag, callback)`](#tagtag-callback)
     * [`popularity(symbol, callback)`](#popularitysymbol-callback)
     * [`options_positions`](#options_positions)
+    * [`options_orders`](#options_orders)
 * [Contributors](#contributors)
 
 <!-- toc stop -->
@@ -915,6 +916,23 @@ var Robinhood = require('robinhood')(credentials, function() {
 //   "quantity": "35.0000"
 // }
 
+```
+
+### `options_orders`
+
+Obtain list of history of option orders
+
+```typescript
+var credentials = require("../credentials.js")();
+var Robinhood = require('robinhood')(credentials, function() {
+    Robinhood.options_orders((err, response, body) => {
+        if (err) {
+            console.error(err);
+        } else {
+            console.log(body);
+        }
+    });
+});
 ```
 
 ### `options_dates`

--- a/src/robinhood.js
+++ b/src/robinhood.js
@@ -54,6 +54,7 @@ function RobinhoodWebApi(opts, callback) {
 
       options_chains: 'options/chains/',
       options_positions: 'options/aggregate_positions/',
+      options_orders: 'options/orders/',
       options_instruments: 'options/instruments/',
       options_marketdata: 'marketdata/options/',
 
@@ -523,6 +524,15 @@ function RobinhoodWebApi(opts, callback) {
     return _request.get(
       {
         uri: _apiUrl + _endpoints.options_positions
+      },
+      callback
+    );
+  };
+
+  api.options_orders = function (callback) {
+    return _request.get(
+      {
+        uri: _apiUrl + _endpoints.options_orders
       },
       callback
     );


### PR DESCRIPTION
@aurbano the orders method seems to only return orders for stock purchases, this should also pull back the history of orders from options transactions as well. 